### PR TITLE
Add missing macro in pkg-config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,11 @@ CFLAGS += $(EXTRA_CFLAGS)
 
 # Customizable optimization flags
 ifneq (,$(filter $(OPT),little LITTLE))
-CFLAGS += -DPERF_GCM_LITTLE -mtune=cortex-a53
+API_FLAGS = -DPERF_GCM_LITTLE
+CFLAGS += $(API_FLAGS) -mtune=cortex-a53
 else ifeq ($(OPT),big)
-CFLAGS += -DPERF_GCM_BIG -mtune=cortex-a57
+API_FLAGS = -DPERF_GCM_BIG
+CFLAGS += $(API_FLAGS) -mtune=cortex-a57
 else
 endif
 
@@ -127,4 +129,4 @@ $(PACKAGE_NAME).pc:
 	@echo 'URL: '$(PACKAGE_URL) >> ${PKGCONFIG}
 	@echo 'Version: '$(PACKAGE_VERSION) >> ${PKGCONFIG}
 	@echo 'Libs: -L$${libdir} -lAArch64crypto' >> ${PKGCONFIG}
-	@echo 'Cflags: -I$${includedir}' >> ${PKGCONFIG}
+	@echo 'Cflags: -I$${includedir} ' $(API_FLAGS) >> ${PKGCONFIG}


### PR DESCRIPTION
When compiling the library with OPT=big or OPT=LITTLE, the makefile
defines a macro that affects the layout of the armv8_cipher_constants_t
structure, which is part of the API. Include the macro in Cflags in
the generated pkg-config file so that the user of the library gets
compiled with the same layout.

This fixes an out-of-bounds array write by AES key expansion when the
library has been built with one of the OPT flags and the application
using the library has been compiled using pkg-config without manually
adding the needed PERF_GCM_* macro.

Signed-off-by: Janne Peltonen <janne.peltonen@nokia.com>